### PR TITLE
Clarify and simplify the integration tests setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <rest-assured.version>3.1.0</rest-assured.version>
     <arquillian-cube.version>1.16.0</arquillian-cube.version>
     <arquillian-junit.version>1.4.0.Final</arquillian-junit.version>
+    <commons-logging.version>1.2</commons-logging.version>
     <junit.version>4.12</junit.version>
     <mksapi.version>4.10.9049</mksapi.version>
     <fabric8.generator.from>
@@ -84,6 +85,11 @@
         <groupId>com.mks.api</groupId>
         <artifactId>mksapi-jar</artifactId>
         <version>${mksapi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>${commons-logging.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -59,17 +59,17 @@
       <scope>test</scope>
     </dependency>
 
+    <!--
+    We need this because Apache httpclient depends on it
+    but the import of the Spring Boot BOM excludes it
+    (which makes sense for regular Spring Boot applications since they use jcl-over-slf4j,
+    but doesn't make sense for test artifacts like this one)
+    -->
     <dependency>
-      <groupId>io.openshift.booster</groupId>
-      <artifactId>spring-boot-istio-distributed-tracing-greeting-service</artifactId>
-      <version>${project.version}</version>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>io.openshift.booster</groupId>
-      <artifactId>spring-boot-istio-distributed-tracing-cute-name-service</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -110,6 +110,25 @@
               <skip>false</skip>
               <profile>aggregate</profile>
             </configuration>
+            <!--
+               We add the dependencies to the two modules that need to be deployed for the tests
+               to run.
+               This is done in order to make FMP pick up the generated Openshift
+               resources file of each module and create an "uber" resources file containing
+               resources for both modules (which is what the aggregate profile above does)
+            -->
+            <dependencies>
+              <dependency>
+                <groupId>io.openshift.booster</groupId>
+                <artifactId>spring-boot-istio-distributed-tracing-greeting-service</artifactId>
+                <version>${project.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>io.openshift.booster</groupId>
+                <artifactId>spring-boot-istio-distributed-tracing-cute-name-service</artifactId>
+                <version>${project.version}</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
The integration tests themselves don't depend on the code of the modules
being tested.
They do however depend on those modules being deployed to Openshift.
In order for FMP to be able to deploy the modules, it needs to be able
to create an uber-resource Openshift file that contains the Openshift
definitions of both modules. That is done using the "aggregate" profile,
but assumes that FMP can find the resource file for each module on it's
classpath.
That is why the configuration has been changed to make the modules
dependencies of FMP instead of the tests themselves.